### PR TITLE
Update dependencies and remove Feign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.0</version>
+        <version>3.5.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -24,16 +24,11 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.17.17</version>
+            <version>7.17.18</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>4.1.0</version>
         </dependency>
 
         <dependency>
@@ -64,13 +59,13 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.3.1</version>
+            <version>3.12.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>au.com.dius.pact.consumer</groupId>
             <artifactId>junit5</artifactId>
-            <version>4.6.5</version>
+            <version>4.6.17</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/example/music_survey_ingest/MusicSurveyIngestApplication.java
+++ b/src/main/java/com/example/music_survey_ingest/MusicSurveyIngestApplication.java
@@ -2,12 +2,10 @@ package com.example.music_survey_ingest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableFeignClients
 @EnableScheduling
 public class MusicSurveyIngestApplication {
 

--- a/src/main/java/com/example/music_survey_ingest/client/MusicSurveyClient.java
+++ b/src/main/java/com/example/music_survey_ingest/client/MusicSurveyClient.java
@@ -1,13 +1,13 @@
 package com.example.music_survey_ingest.client;
 
 import com.example.music_survey_ingest.client.dto.GenreVotingDto;
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
 
 import java.util.List;
 
-@FeignClient(name = "music-survey-client", url = "${client.music-survey.base-url}")
+@HttpExchange(url = "${client.music-survey.base-url}")
 public interface MusicSurveyClient {
-    @GetMapping("/api/v1/voting")
+    @GetExchange("/api/v1/voting")
     List<GenreVotingDto> getAll();
 }

--- a/src/main/java/com/example/music_survey_ingest/config/MusicSurveyClientConfig.java
+++ b/src/main/java/com/example/music_survey_ingest/config/MusicSurveyClientConfig.java
@@ -1,0 +1,24 @@
+package com.example.music_survey_ingest.config;
+
+import com.example.music_survey_ingest.client.MusicSurveyClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import org.springframework.web.service.invoker.RestClientAdapter;
+
+@Configuration
+public class MusicSurveyClientConfig {
+
+    @Value("${client.music-survey.base-url}")
+    private String baseUrl;
+
+    @Bean
+    MusicSurveyClient musicSurveyClient(RestClient.Builder builder) {
+        RestClient restClient = builder.baseUrl(baseUrl).build();
+        HttpServiceProxyFactory factory =
+                HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build();
+        return factory.createClient(MusicSurveyClient.class);
+    }
+}

--- a/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestApplicationTests.java
+++ b/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestApplicationTests.java
@@ -5,14 +5,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
-@EnableFeignClients
 @Testcontainers
 class MusicSurveyIngestApplicationTests {
     @Container

--- a/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestIT.java
+++ b/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestIT.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -38,7 +37,6 @@ import static org.springframework.util.StreamUtils.copyToString;
 @AutoConfigureMockMvc
 @Testcontainers
 @ActiveProfiles("test")
-@EnableFeignClients
 @WireMockTest(httpPort = 9010)
 public class MusicSurveyIngestIT {
     @Container

--- a/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestPactIT.java
+++ b/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestPactIT.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -36,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("pact")
-@EnableFeignClients
 @PactTestFor(pactVersion = PactSpecVersion.V4)
 @MockServerConfig(hostInterface = "localhost", port = "9009")
 @PactConsumerTest


### PR DESCRIPTION
## Summary
- update dependencies in the pom
- replace Feign client with new HttpExchange interface
- remove `EnableFeignClients` from application and tests
- configure `MusicSurveyClient` using RestClient

## Testing
- `mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684583f6c5408326806a8f4850385c50