### PR TITLE
Integrate Surefire/Failsafe and rename integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,37 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestApplicationIT.java
+++ b/src/test/java/com/example/music_survey_ingest/MusicSurveyIngestApplicationIT.java
@@ -5,14 +5,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
 @Testcontainers
-class MusicSurveyIngestApplicationTests {
+@ActiveProfiles("test")
+class MusicSurveyIngestApplicationIT {
     @Container
     private static final ElasticsearchContainer elasticsearchContainer = new SurveyIngestElasticsearchContainer();
 


### PR DESCRIPTION
## Summary
- add Maven Surefire and Failsafe plugins to pom
- rename `MusicSurveyIngestApplicationTests` to `MusicSurveyIngestApplicationIT`
- mark the test with `@ActiveProfiles("test")`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_684589d4cd908326a781bee9409788d6