### PR TITLE
Add Kafka consumer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
             <version>7.17.18</version>
@@ -39,6 +43,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/example/music_survey_ingest/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/music_survey_ingest/config/KafkaConsumerConfig.java
@@ -1,0 +1,44 @@
+package com.example.music_survey_ingest.config;
+
+import com.example.music_survey_ingest.dto.SurveyDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+@Profile("kafka")
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, SurveyDto> consumerFactory(
+            @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
+                new JsonDeserializer<>(SurveyDto.class, false));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SurveyDto> kafkaListenerContainerFactory(
+            ConsumerFactory<String, SurveyDto> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, SurveyDto> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}

--- a/src/main/java/com/example/music_survey_ingest/kafka/VotingConsumer.java
+++ b/src/main/java/com/example/music_survey_ingest/kafka/VotingConsumer.java
@@ -1,0 +1,24 @@
+package com.example.music_survey_ingest.kafka;
+
+import com.example.music_survey_ingest.dto.SurveyDto;
+import com.example.music_survey_ingest.service.VotingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Profile("kafka")
+public class VotingConsumer {
+
+    private final VotingService votingService;
+
+    @KafkaListener(topics = "${app.kafka.topic:music-survey}", groupId = "${app.kafka.consumer-group:music-survey-group}")
+    public void listen(@Payload SurveyDto surveyDto) {
+        votingService.save(List.of(surveyDto));
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,8 +2,14 @@ spring:
   data:
     elasticsearch:
       cluster-nodes: elasticsearch:9200
+  kafka:
+    bootstrap-servers: kafka:9092
 client:
   music-survey:
     base-url: http://music-survey-backend:8070/music-survey
   elasticsearch:
     host: elasticsearch
+app:
+  kafka:
+    topic: music-survey
+    consumer-group: music-survey-group

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,15 @@ spring:
       repositories: enabled=true
   main:
     allow-bean-definition-overriding: true
+  kafka:
+    bootstrap-servers: localhost:9092
 client:
   music-survey:
     base-url: http://localhost:8070/music-survey
   elasticsearch:
     host: localhost
     port: 9200
+app:
+  kafka:
+    topic: music-survey
+    consumer-group: music-survey-group


### PR DESCRIPTION
## Summary
- add Spring Kafka dependencies
- configure consumer factory with JSON deserializer
- implement `VotingConsumer` listening on configurable topic
- configure Kafka properties in YAML files

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b3cd7f33c8326a3db5bbf4f67e472